### PR TITLE
T/38 Make remove on image abortion permanent

### DIFF
--- a/src/imageuploadengine.js
+++ b/src/imageuploadengine.js
@@ -151,9 +151,9 @@ export default class ImageUploadEngine extends Plugin {
 
 				clean();
 
-				// Remove image from insertion batch.
+				// Permanently remove image from insertion batch.
 				doc.enqueueChanges( () => {
-					batch.remove( imageElement );
+					batch.remove( imageElement, true );
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: When image upload is aborted, now the "image placeholder" element is permanently removed so it is not reinserted on undo. Closes #38.

---

### Additional information

Additionally, `uploadStatus` attribute does not change on undo/redo, although this is less important, as image element is in graveyard anyway. Still, this means that there are less deltas created and applied so there are less objects in `engine.model.History` and it is easier to debug.