### PR TITLE
Bound ImageUploadButton#isEnabled to ImageUploadCommand#isEnabled.

### DIFF
--- a/src/imageuploadbutton.js
+++ b/src/imageuploadbutton.js
@@ -36,6 +36,7 @@ export default class ImageUploadButton extends Plugin {
 		// Setup `insertImage` button.
 		editor.ui.componentFactory.add( 'insertImage', locale => {
 			const view = new FileDialogButtonView( locale );
+			const command = editor.commands.get( 'imageUpload' );
 
 			view.set( {
 				label: t( 'Insert image' ),
@@ -44,6 +45,8 @@ export default class ImageUploadButton extends Plugin {
 				acceptedType: 'image/*',
 				allowMultipleFiles: true
 			} );
+
+			view.bind( 'isEnabled' ).to( command );
 
 			view.on( 'done', ( evt, files ) => {
 				for ( const file of files ) {

--- a/tests/imageuploadbutton.js
+++ b/tests/imageuploadbutton.js
@@ -37,6 +37,19 @@ describe( 'ImageUploadButton', () => {
 		expect( button ).to.be.instanceOf( FileDialogButtonView );
 	} );
 
+	it( 'should be disabled while ImageUploadCommand is disabled', () => {
+		const button = editor.ui.componentFactory.create( 'insertImage' );
+		const command = editor.commands.get( 'imageUpload' );
+
+		command.isEnabled = true;
+
+		expect( button.isEnabled ).to.true;
+
+		command.isEnabled = false;
+
+		expect( button.isEnabled ).to.false;
+	} );
+
 	it( 'should execute imageUpload command', () => {
 		const executeStub = sinon.stub( editor, 'execute' );
 		const button = editor.ui.componentFactory.create( 'insertImage' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Bound `ImageUploadButton#isEnabled` to `ImageUploadCommand#isEnabled`. Closes #43.