### PR TITLE
T/35: Fixed image upload on Safari and Edge

### DIFF
--- a/src/imageuploadbutton.js
+++ b/src/imageuploadbutton.js
@@ -50,7 +50,7 @@ export default class ImageUploadButton extends Plugin {
 			view.bind( 'isEnabled' ).to( command );
 
 			view.on( 'done', ( evt, files ) => {
-				for ( const file of files ) {
+				for ( const file of Array.from( files ) ) {
 					const insertAt = findOptimalInsertionPosition( editor.document.selection );
 
 					if ( isImageType( file ) ) {

--- a/tests/imageuploadbutton.js
+++ b/tests/imageuploadbutton.js
@@ -130,5 +130,19 @@ describe( 'ImageUploadButton', () => {
 		button.fire( 'done', [ file ] );
 		sinon.assert.notCalled( executeStub );
 	} );
+
+	it( 'should work even if the FileList does not support iterators', () => {
+		const executeStub = sinon.stub( editor, 'execute' );
+		const button = editor.ui.componentFactory.create( 'insertImage' );
+		const files = {
+			0: createNativeFileMock(),
+			length: 1
+		};
+
+		button.fire( 'done', files );
+		sinon.assert.calledOnce( executeStub );
+		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'imageUpload' );
+		expect( executeStub.firstCall.args[ 1 ].file ).to.equal( files[ 0 ] );
+	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent from calling `for...of` loop on `FileList` which does not support `Symbol.iterator` yet. Upload will work on Safari and Edge. Closes #35.
