### PR TITLE
T/32: Image dropped on another image redirects to file's path

### DIFF
--- a/src/imageuploadengine.js
+++ b/src/imageuploadengine.js
@@ -64,6 +64,11 @@ export default class ImageUploadEngine extends Plugin {
 			}
 		} );
 
+		// Prevents from browser redirecting to drag-end-dropped image.
+		editor.editing.view.on( 'dragover', ( evt, data ) => {
+			data.preventDefault();
+		} );
+
 		doc.on( 'change', ( evt, type, data ) => {
 			// Listen on document changes and:
 			// * start upload process when image with `uploadId` attribute is inserted,

--- a/tests/imageuploadengine.js
+++ b/tests/imageuploadengine.js
@@ -359,4 +359,14 @@ describe( 'ImageUploadEngine', () => {
 
 		nativeReaderMock.mockSuccess( base64Sample );
 	} );
+
+	it( 'should prevent from browser redirecting when an image is dropped on another image', () => {
+		const spy = testUtils.sinon.spy();
+
+		editor.editing.view.fire( 'dragover', {
+			preventDefault: spy
+		} );
+
+		expect( spy.calledOnce ).to.equal( true );
+	} );
 } );

--- a/tests/manual/imageupload.md
+++ b/tests/manual/imageupload.md
@@ -5,6 +5,9 @@
 1. Press "Upload progress" button couple times to simulate upload process.
 1. After uploading is complete your image should be replaced with sample image from server.
 
+On the occasionn – when you drop an image on another image in the editor,
+your browser [**should not** redirect to the image](https://github.com/ckeditor/ckeditor5-upload/issues/32).
+
 Repeat all the steps with:
 * dropping multiple images,
 * using toolbar button to add one and multiple images,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: An image dropped on another image will not redirect the browser to the file's path. Closes #32.

---

### Additional information

* Requires: https://github.com/ckeditor/ckeditor5-clipboard/compare/master...t/ckeditor5-upload/32
* CI: https://travis-ci.org/ckeditor/ckeditor5/builds/266940447
