### PR TITLE
Fix: Improved destroying of FileDialogButtonView.

### DIFF
--- a/src/imageuploadbutton.js
+++ b/src/imageuploadbutton.js
@@ -40,11 +40,14 @@ export default class ImageUploadButton extends Plugin {
 			const command = editor.commands.get( 'imageUpload' );
 
 			view.set( {
-				label: t( 'Insert image' ),
-				icon: imageIcon,
-				tooltip: true,
 				acceptedType: 'image/*',
 				allowMultipleFiles: true
+			} );
+
+			view.buttonView.set( {
+				label: t( 'Insert image' ),
+				icon: imageIcon,
+				tooltip: true
 			} );
 
 			view.bind( 'isEnabled' ).to( command );

--- a/src/ui/filedialogbuttonview.js
+++ b/src/ui/filedialogbuttonview.js
@@ -32,6 +32,7 @@ export default class FileDialogButtonView extends ButtonView {
 		 * @member {module:upload/ui/filedialogbuttonview~FileInputView}
 		 */
 		this.fileInputView = new FileInputView( locale );
+		this.addChildren( this.fileInputView );
 
 		/**
 		 * Accepted file types. Can be provided in form of file extensions, media type or one of:
@@ -42,7 +43,7 @@ export default class FileDialogButtonView extends ButtonView {
 		 * @observable
 		 * @member {String} #acceptedType
 		 */
-		this.fileInputView.bind( 'acceptedType' ).to( this, 'acceptedType' );
+		this.fileInputView.bind( 'acceptedType' ).to( this );
 
 		/**
 		 * Indicates if multiple files can be selected. Defaults to `true`.
@@ -50,8 +51,7 @@ export default class FileDialogButtonView extends ButtonView {
 		 * @observable
 		 * @member {Boolean} #allowMultipleFiles
 		 */
-		this.set( 'allowMultipleFiles', false );
-		this.fileInputView.bind( 'allowMultipleFiles' ).to( this, 'allowMultipleFiles' );
+		this.fileInputView.bind( 'allowMultipleFiles' ).to( this );
 
 		/**
 		 * Fired when file dialog is closed with file selected.
@@ -70,7 +70,13 @@ export default class FileDialogButtonView extends ButtonView {
 		this.on( 'execute', () => {
 			this.fileInputView.open();
 		} );
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		super.init();
 		document.body.appendChild( this.fileInputView.element );
 	}
 
@@ -78,9 +84,8 @@ export default class FileDialogButtonView extends ButtonView {
 	 * @inheritDoc
 	 */
 	destroy() {
-		document.body.removeChild( this.fileInputView.element );
-
 		super.destroy();
+		this.fileInputView.element.remove();
 	}
 }
 

--- a/src/ui/filedialogbuttonview.js
+++ b/src/ui/filedialogbuttonview.js
@@ -108,6 +108,13 @@ export default class FileDialogButtonView extends View {
 			this._fileInputView.open();
 		} );
 	}
+
+	/**
+	 * Focuses the {@link #buttonView}.
+	 */
+	focus() {
+		this.buttonView.focus();
+	}
 }
 
 /**

--- a/src/ui/filedialogbuttonview.js
+++ b/src/ui/filedialogbuttonview.js
@@ -12,10 +12,29 @@ import View from '@ckeditor/ckeditor5-ui/src/view';
 import Template from '@ckeditor/ckeditor5-ui/src/template';
 
 /**
- * File Dialog button view.
+ * The file dialog button view.
  *
- * This component implements wrapper element with {@link module:ui/button/buttonview~ButtonView ButtonView}
- * and and hidden `input[type="file"]` inside.
+ * This component provides a button that opens the native file selection dialog.
+ * It can be used to implement the UI of a file upload feature.
+ *
+ *		const view = new FileDialogButtonView( locale );
+ *
+ *		view.set( {
+ *			acceptedType: 'image/*',
+ *			allowMultipleFiles: true
+ *		} );
+ *
+ *		view.buttonView.set( {
+ *			label: t( 'Insert image' ),
+ *			icon: imageIcon,
+ *			tooltip: true
+ *		} );
+ *
+ *		view.on( 'done', ( evt, files ) => {
+ *			for ( const file of Array.from( files ) ) {
+ *				console.log( 'Selected file', file );
+ *			}
+ *		} );
  *
  * @extends module:ui/view~View
  */
@@ -27,14 +46,14 @@ export default class FileDialogButtonView extends View {
 		super( locale );
 
 		/**
-		 * Button View.
+		 * The button view of the component.
 		 *
 		 * @member {module:ui/button/buttonview~ButtonView}
 		 */
 		this.buttonView = new ButtonView( locale );
 
 		/**
-		 * Hidden input view used to execute file dialog.
+		 * A hidden `<input>` view used to execute file dialog.
 		 *
 		 * @protected
 		 * @member {module:upload/ui/filedialogbuttonview~FileInputView}
@@ -63,11 +82,11 @@ export default class FileDialogButtonView extends View {
 		/**
 		 * Fired when file dialog is closed with file selected.
 		 *
-		 *	fileDialogButtonView.on( 'done', ( evt, files ) => {
-		 *		for ( const file of files ) {
-		 *			processFile( file );
+		 *		view.on( 'done', ( evt, files ) => {
+		 *			for ( const file of files ) {
+		 *				console.log( 'Selected file', file );
+		 *			}
 		 *		}
-		 *	}
 		 *
 		 * @event done
 		 * @param {Array.<File>} files Array of selected files.
@@ -92,7 +111,7 @@ export default class FileDialogButtonView extends View {
 }
 
 /**
- * Hidden file input view class.
+ * The hidden file input view class.
  *
  * @private
  * @extends {module:ui/view~View}

--- a/src/ui/filedialogbuttonview.js
+++ b/src/ui/filedialogbuttonview.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document */
-
 /**
  * @module upload/ui/filedialogbuttonview
  */
@@ -16,9 +14,12 @@ import Template from '@ckeditor/ckeditor5-ui/src/template';
 /**
  * File Dialog button view.
  *
- * @extends module:ui/button/buttonview~ButtonView
+ * This component implements wrapper element with {@link module:ui/button/buttonview~ButtonView ButtonView}
+ * and and hidden `input[type="file"]` inside.
+ *
+ * @extends module:ui/view~View
  */
-export default class FileDialogButtonView extends ButtonView {
+export default class FileDialogButtonView extends View {
 	/**
 	 * @inheritDoc
 	 */
@@ -26,13 +27,19 @@ export default class FileDialogButtonView extends ButtonView {
 		super( locale );
 
 		/**
-		 * Hidden input view used to execute file dialog. It will be hidden and added to the end of `document.body`.
+		 * Button View.
+		 *
+		 * @member {module:ui/button/buttonview~ButtonView}
+		 */
+		this.buttonView = new ButtonView( locale );
+
+		/**
+		 * Hidden input view used to execute file dialog.
 		 *
 		 * @protected
 		 * @member {module:upload/ui/filedialogbuttonview~FileInputView}
 		 */
-		this.fileInputView = new FileInputView( locale );
-		this.addChildren( this.fileInputView );
+		this._fileInputView = new FileInputView( locale );
 
 		/**
 		 * Accepted file types. Can be provided in form of file extensions, media type or one of:
@@ -43,7 +50,7 @@ export default class FileDialogButtonView extends ButtonView {
 		 * @observable
 		 * @member {String} #acceptedType
 		 */
-		this.fileInputView.bind( 'acceptedType' ).to( this );
+		this._fileInputView.bind( 'acceptedType' ).to( this );
 
 		/**
 		 * Indicates if multiple files can be selected. Defaults to `true`.
@@ -51,7 +58,7 @@ export default class FileDialogButtonView extends ButtonView {
 		 * @observable
 		 * @member {Boolean} #allowMultipleFiles
 		 */
-		this.fileInputView.bind( 'allowMultipleFiles' ).to( this );
+		this._fileInputView.bind( 'allowMultipleFiles' ).to( this );
 
 		/**
 		 * Fired when file dialog is closed with file selected.
@@ -65,27 +72,22 @@ export default class FileDialogButtonView extends ButtonView {
 		 * @event done
 		 * @param {Array.<File>} files Array of selected files.
 		 */
-		this.fileInputView.delegate( 'done' ).to( this );
+		this._fileInputView.delegate( 'done' ).to( this );
 
-		this.on( 'execute', () => {
-			this.fileInputView.open();
+		this.template = new Template( {
+			tag: 'span',
+			attributes: {
+				class: 'ck-file-dialog-button',
+			},
+			children: [
+				this.buttonView,
+				this._fileInputView
+			]
 		} );
-	}
 
-	/**
-	 * @inheritDoc
-	 */
-	init() {
-		super.init();
-		document.body.appendChild( this.fileInputView.element );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	destroy() {
-		super.destroy();
-		this.fileInputView.element.remove();
+		this.buttonView.on( 'execute', () => {
+			this._fileInputView.open();
+		} );
 	}
 }
 

--- a/tests/ui/filedialogbuttonview.js
+++ b/tests/ui/filedialogbuttonview.js
@@ -3,9 +3,9 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document */
-
 import FileDialogButtonView from '../../src/ui/filedialogbuttonview';
+import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import View from '@ckeditor/ckeditor5-ui/src/view';
 
 describe( 'FileDialogButtonView', () => {
 	let view, localeMock;
@@ -17,43 +17,53 @@ describe( 'FileDialogButtonView', () => {
 		return view.init();
 	} );
 
-	it( 'should append input view to document body', () => {
-		expect( document.body.contains( view.fileInputView.element ) ).to.true;
+	it( 'should be rendered from a template', () => {
+		expect( view.element.classList.contains( 'ck-file-dialog-button' ) ).to.true;
 	} );
 
-	it( 'should remove input view from body after destroy', () => {
-		view.destroy();
+	describe( 'child views', () => {
+		describe( 'button view', () => {
+			it( 'should be rendered', () => {
+				expect( view.buttonView ).to.instanceof( ButtonView );
+				expect( view.buttonView ).to.equal( view.template.children.get( 0 ) );
+			} );
 
-		expect( document.body.contains( view.fileInputView.element ) ).to.false;
-	} );
+			it( 'should open file dialog on execute', () => {
+				const spy = sinon.spy( view._fileInputView, 'open' );
+				view.buttonView.fire( 'execute' );
 
-	it( 'should open file dialog on execute', () => {
-		const spy = sinon.spy( view.fileInputView, 'open' );
-		view.fire( 'execute' );
-
-		sinon.assert.calledOnce( spy );
-	} );
-
-	it( 'should pass acceptedType to input view', () => {
-		view.set( { acceptedType: 'audio/*' } );
-
-		expect( view.fileInputView.acceptedType ).to.equal( 'audio/*' );
-	} );
-
-	it( 'should pass allowMultipleFiles to input view', () => {
-		view.set( { allowMultipleFiles: true } );
-
-		expect( view.fileInputView.allowMultipleFiles ).to.be.true;
-	} );
-
-	it( 'should delegate input view done event', done => {
-		const files = [];
-
-		view.on( 'done', ( evt, data ) => {
-			expect( data ).to.equal( files );
-			done();
+				sinon.assert.calledOnce( spy );
+			} );
 		} );
 
-		view.fileInputView.fire( 'done', files );
+		describe( 'file dialog', () => {
+			it( 'should be rendered', () => {
+				expect( view._fileInputView ).to.instanceof( View );
+				expect( view._fileInputView ).to.equal( view.template.children.get( 1 ) );
+			} );
+
+			it( 'should be bound to view#acceptedType', () => {
+				view.set( { acceptedType: 'audio/*' } );
+
+				expect( view._fileInputView.acceptedType ).to.equal( 'audio/*' );
+			} );
+
+			it( 'should be bound to view#allowMultipleFiles', () => {
+				view.set( { allowMultipleFiles: true } );
+
+				expect( view._fileInputView.allowMultipleFiles ).to.be.true;
+			} );
+
+			it( 'should delegate done event to view', () => {
+				const spy = sinon.spy();
+				const files = [];
+
+				view.on( 'done', spy );
+				view._fileInputView.fire( 'done', files );
+
+				sinon.assert.calledOnce( spy );
+				expect( spy.lastCall.args[ 1 ] ).to.equal( files );
+			} );
+		} );
 	} );
 } );

--- a/tests/ui/filedialogbuttonview.js
+++ b/tests/ui/filedialogbuttonview.js
@@ -66,4 +66,14 @@ describe( 'FileDialogButtonView', () => {
 			} );
 		} );
 	} );
+
+	describe( 'focus()', () => {
+		it( 'should focus view#buttonView', () => {
+			const spy = sinon.spy( view.buttonView, 'focus' );
+
+			view.focus();
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
 } );

--- a/tests/ui/filedialogbuttonview.js
+++ b/tests/ui/filedialogbuttonview.js
@@ -5,33 +5,26 @@
 
 /* globals document */
 
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import FileDialogButtonView from '../../src/ui/filedialogbuttonview';
 
 describe( 'FileDialogButtonView', () => {
-	let view, editor;
+	let view, localeMock;
 
 	beforeEach( () => {
-		const editorElement = document.createElement( 'div' );
-		document.body.appendChild( editorElement );
+		localeMock = { t: val => val };
+		view = new FileDialogButtonView( localeMock );
 
-		return ClassicEditor
-			.create( editorElement )
-			.then( newEditor => {
-				editor = newEditor;
-
-				view = new FileDialogButtonView( editor.locale );
-			} );
+		return view.init();
 	} );
 
 	it( 'should append input view to document body', () => {
-		expect( view.fileInputView.element.parentNode ).to.equal( document.body );
+		expect( document.body.contains( view.fileInputView.element ) ).to.true;
 	} );
 
 	it( 'should remove input view from body after destroy', () => {
 		view.destroy();
 
-		expect( view.fileInputView.element.parentNode ).to.be.null;
+		expect( document.body.contains( view.fileInputView.element ) ).to.false;
 	} );
 
 	it( 'should open file dialog on execute', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved destroying of `FileDialogButtonView`. Closes #66.

BREAKING CHANGE: The `FileDialogButtonView` is not a `ButtonView` instance anymore. `ButtonView` is implemented as a `FileDialogButtonView` child and is available under the `FileDialogButtonView#buttonView` property.