### PR TITLE
Pass DOMStringList through Array.from() to be safe on Edge

### DIFF
--- a/src/imageuploadengine.js
+++ b/src/imageuploadengine.js
@@ -206,5 +206,5 @@ export default class ImageUploadEngine extends Plugin {
 // @param {module:clipboard/datatransfer~DataTransfer} dataTransfer
 // @returns {Boolean}
 export function isHtmlIncluded( dataTransfer ) {
-	return dataTransfer.types.indexOf( 'text/html' ) > -1 && dataTransfer.getData( 'text/html' ) !== '';
+	return Array.from( dataTransfer.types ).includes( 'text/html' ) && dataTransfer.getData( 'text/html' ) !== '';
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed a bug on Edge where nothing can be pasted because we try to use a non-existing `indexOf()` method on `DataTransfer#types`. Closes #70.

---

### Additional information

Internal because we broke it in this version.