### PR TITLE
Event names don't have to be normalized to consumable types anymore

### DIFF
--- a/src/imageuploadprogress.js
+++ b/src/imageuploadprogress.js
@@ -8,7 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import { eventNameToConsumableType } from '@ckeditor/ckeditor5-engine/src/conversion/model-to-view-converters';
 import FileRepository from './filerepository';
 import uploadingPlaceholder from '../theme/icons/image_placeholder.svg';
 import UIElement from '@ckeditor/ckeditor5-engine/src/view/uielement';
@@ -61,7 +60,7 @@ export default class ImageUploadProgress extends Plugin {
 		const modelImage = data.item;
 		const uploadId = modelImage.getAttribute( 'uploadId' );
 
-		if ( !consumable.consume( data.item, eventNameToConsumableType( evt.name ) ) || !uploadId ) {
+		if ( !consumable.consume( data.item, evt.name ) || !uploadId ) {
 			return;
 		}
 

--- a/tests/imageuploadengine.js
+++ b/tests/imageuploadengine.js
@@ -20,7 +20,6 @@ import { AdapterMock, createNativeFileMock, NativeFileReaderMock } from './_util
 
 import { setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
-import { eventNameToConsumableType } from '@ckeditor/ckeditor5-engine/src/conversion/model-to-view-converters';
 import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 
@@ -199,7 +198,7 @@ describe( 'ImageUploadEngine', () => {
 
 	it( 'should not convert image\'s uploadId attribute if is consumed already', () => {
 		editor.editing.modelToView.on( 'attribute:uploadId:image', ( evt, data, consumable ) => {
-			consumable.consume( data.item, eventNameToConsumableType( evt.name ) );
+			consumable.consume( data.item, evt.name );
 		}, { priority: 'high' } );
 
 		setModelData( model, '<image uploadId="1234"></image>' );

--- a/tests/imageuploadprogress.js
+++ b/tests/imageuploadprogress.js
@@ -17,7 +17,6 @@ import FileRepository from '../src/filerepository';
 import { AdapterMock, createNativeFileMock, NativeFileReaderMock } from './_utils/mocks';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
-import { eventNameToConsumableType } from '@ckeditor/ckeditor5-engine/src/conversion/model-to-view-converters';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import svgPlaceholder from '../theme/icons/image_placeholder.svg';
 
@@ -159,7 +158,7 @@ describe( 'ImageUploadProgress', () => {
 
 	it( 'should not process attribute change if it is already consumed', () => {
 		editor.editing.modelToView.on( 'attribute:uploadStatus:image', ( evt, data, consumable ) => {
-			consumable.consume( data.item, eventNameToConsumableType( evt.name ) );
+			consumable.consume( data.item, evt.name );
 		}, { priority: 'highest' } );
 
 		setModelData( model, '<paragraph>[]foo</paragraph>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Event names don't have to be normalized to consumable types anymore.

---

### Additional information

This PR is related to https://github.com/ckeditor/ckeditor5-engine/pull/1241