### PR TITLE
FileLoader now accepts Promise instead of a File instance

### DIFF
--- a/src/filereader.js
+++ b/src/filereader.js
@@ -57,7 +57,7 @@ export default class FileReader {
 	 * Reads the provided file.
 	 *
 	 * @param {File} file Native File object.
-	 * @returns {Promise} Returns a promise that will be resolved with file's content.
+	 * @returns {Promise.<String>} Returns a promise that will be resolved with file's content.
 	 * The promise will be rejected in case of an error or when the reading process is aborted.
 	 */
 	read( file ) {

--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -370,9 +370,9 @@ class FileLoader {
 	}
 
 	/**
-	 * Returns a `Promise` which resolves to a `File` instance associated with this file loader.
+	 * A `Promise` which resolves to a `File` instance associated with this file loader.
 	 *
-	 * @type {Promise.<File>}
+	 * @type {Promise.<File|null>}
 	 */
 	get file() {
 		if ( !this._filePromiseWrapper ) {

--- a/tests/filerepository.js
+++ b/tests/filerepository.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals window, setTimeout */
+/* globals window */
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `FileLoader` now accepts `Promise` instead of a `File` instance. Closes #87.

BREAKING CHANGE: The `FileLoader.file` property was changed to a getter which returns a native `Promise` instance instead of a `File` instance. The returned promise resolves to a `File` instance.

---

### Additional information

See #87 for technical explanations what was changed.

This change also required some updates in `ckeditor5-image` and `ckeditor5-easy-image` plugins (because of a change in how `loader.file` works and it's async nature):

* Related `ckeditor5-image` PR: https://github.com/ckeditor/ckeditor5-image/pull/258.
* Related `ckeditor5-easy-image` PR: https://github.com/ckeditor/ckeditor5-easy-image/pull/22.
* Related `ckeditor5-adapter-ckfinder` PR: https://github.com/ckeditor/ckeditor5-adapter-ckfinder/pull/13.