### PR TITLE
Add catch block for failed file promise in `FileRepository`

### DIFF
--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -188,7 +188,7 @@ export default class FileRepository extends Plugin {
 			} );
 		}
 
-		// Catch the file promise rejection. If there are no `catch` closures, the browser
+		// Catch the file promise rejection. If there are no `catch` clause, the browser
 		// will throw an error (see https://github.com/ckeditor/ckeditor5-upload/pull/90).
 		loader.file.catch( () => {
 			// The error will be handled by `FileLoader` so no action is required here.

--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -183,9 +183,13 @@ export default class FileRepository extends Plugin {
 
 		// Store also file => loader mapping so loader can be retrieved by file instance returned upon Promise resolution.
 		if ( fileOrPromise instanceof Promise ) {
-			loader.file.then( file => {
-				this._loadersMap.set( file, loader );
-			} );
+			loader.file
+				.then( file => {
+					this._loadersMap.set( file, loader );
+				} ).catch( () => {
+					// There was an error fetching file, so do not add anything to `this._loadersMap`.
+					// Also the error will be handled by `FileLoader` so no action is required here.
+				} );
 		}
 
 		loader.on( 'change:uploaded', () => {

--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -183,14 +183,16 @@ export default class FileRepository extends Plugin {
 
 		// Store also file => loader mapping so loader can be retrieved by file instance returned upon Promise resolution.
 		if ( fileOrPromise instanceof Promise ) {
-			loader.file
-				.then( file => {
-					this._loadersMap.set( file, loader );
-				} ).catch( () => {
-					// There was an error fetching file, so do not add anything to `this._loadersMap`.
-					// Also the error will be handled by `FileLoader` so no action is required here.
-				} );
+			loader.file.then( file => {
+				this._loadersMap.set( file, loader );
+			} );
 		}
+
+		// Catch the file promise rejection. If there are no `catch` closures, the browser
+		// will throw an error (see https://github.com/ckeditor/ckeditor5-upload/pull/90).
+		loader.file.catch( () => {
+			// The error will be handled by `FileLoader` so no action is required here.
+		} );
 
 		loader.on( 'change:uploaded', () => {
 			let aggregatedUploaded = 0;

--- a/tests/filerepository.js
+++ b/tests/filerepository.js
@@ -200,6 +200,24 @@ describe( 'FileRepository', () => {
 			expect( fileRepository.uploadTotal ).to.equal( 500 );
 			expect( fileRepository.uploadedPercent ).to.equal( 20 );
 		} );
+
+		it( 'should catch if file promise rejected (file)', () => {
+			const catchSpy = testUtils.sinon.spy( Promise.prototype, 'catch' );
+
+			fileRepository.createLoader( createNativeFileMock() );
+
+			// One call originates from `loader._createFilePromiseWrapper()` and other from `fileRepository.createLoader()`.
+			expect( catchSpy.callCount ).to.equal( 2 );
+		} );
+
+		it( 'should catch if file promise rejected (promise)', () => {
+			const catchSpy = testUtils.sinon.spy( Promise.prototype, 'catch' );
+
+			fileRepository.createLoader( new Promise( () => {} ) );
+
+			// One call originates from `loader._createFilePromiseWrapper()` and other from `fileRepository.createLoader()`.
+			expect( catchSpy.callCount ).to.equal( 2 );
+		} );
 	} );
 
 	describe( 'getLoader()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Add catch block for failed file promise in `FileRepository`.

---

### Additional information

Related to https://github.com/ckeditor/ckeditor5-image/pull/264. In cases where `File` constructor is not supported or file promise fails for any other reason, `loader.file.then` may throw an error if there is no `catch` there (or anywhere in the code).

![image](https://user-images.githubusercontent.com/1061942/51253068-a9275d80-199d-11e9-84da-6e75388c5e9c.png)

In short, if there is no `loader.file.catch` in the code (some upload adapters may have it, some not), the code before modification threw an error on rejected promise.

