### PR TITLE
Fix unhandled promise rejections errors.

### DIFF
--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -186,19 +186,14 @@ export default class FileRepository extends Plugin {
 
 		// Store also file => loader mapping so loader can be retrieved by file instance returned upon Promise resolution.
 		if ( fileOrPromise instanceof Promise ) {
-			loader.file.then( file => {
-				this._loadersMap.set( file, loader );
-			} ).catch( () => {
-				// Catch the file promise rejection. If there are no `catch` clause, the browser
-				// will throw an error (see https://github.com/ckeditor/ckeditor5-upload/pull/90).
-				// The error will be handled by `FileLoader` so no action is required here.
-			} );
-		} else {
-			// Catch the file promise rejection. If there are no `catch` clause, the browser
-			// will throw an error (see https://github.com/ckeditor/ckeditor5-upload/pull/90).
-			loader.file.catch( () => {
-				// The error will be handled by `FileLoader` so no action is required here.
-			} );
+			loader.file
+				.then( file => {
+					this._loadersMap.set( file, loader );
+				} )
+				// Every then() must have a catch().
+				// File loader state (and rejections) are handled in read() and upload().
+				// Also, see the "does not swallow the file promise rejection" test.
+				.catch( () => {} );
 		}
 
 		loader.on( 'change:uploaded', () => {
@@ -295,7 +290,7 @@ class FileLoader {
 		/**
 		 * Additional wrapper over the initial file promise passed to this loader.
 		 *
-		 * @private
+		 * @protected
 		 * @member {module:upload/filerepository~FilePromiseWrapper}
 		 */
 		this._filePromiseWrapper = this._createFilePromiseWrapper( filePromise );
@@ -442,7 +437,7 @@ class FileLoader {
 
 		this.status = 'reading';
 
-		return this._filePromiseWrapper.promise
+		return this.file
 			.then( file => this._reader.read( file ) )
 			.then( data => {
 				// Edge case: reader was aborted after file was read - double check for proper status.
@@ -495,7 +490,7 @@ class FileLoader {
 
 		this.status = 'uploading';
 
-		return this._filePromiseWrapper.promise
+		return this.file
 			.then( () => this._adapter.upload() )
 			.then( data => {
 				this.uploadResponse = data;
@@ -521,6 +516,11 @@ class FileLoader {
 		this.status = 'aborted';
 
 		if ( !this._filePromiseWrapper.isFulfilled ) {
+			// Edge case: file loader is aborted before read() is called
+			// so it might happen that no one handled the rejection of this promise.
+			// See https://github.com/ckeditor/ckeditor5-upload/pull/100
+			this._filePromiseWrapper.promise.catch( () => {} );
+
 			this._filePromiseWrapper.rejecter( 'aborted' );
 		} else if ( status == 'reading' ) {
 			this._reader.abort();
@@ -555,7 +555,6 @@ class FileLoader {
 		const wrapper = {};
 
 		wrapper.promise = new Promise( ( resolve, reject ) => {
-			wrapper.resolver = resolve;
 			wrapper.rejecter = reject;
 			wrapper.isFulfilled = false;
 
@@ -631,9 +630,9 @@ mix( FileLoader, ObservableMixin );
  * Object returned by {@link module:upload/filerepository~FileLoader#_createFilePromiseWrapper} method
  * to add more control over the initial file promise passed to {@link module:upload/filerepository~FileLoader}.
  *
+ * @protected
  * @typedef {Object} module:upload/filerepository~FilePromiseWrapper
  * @property {Promise.<File>} promise Wrapper promise which can be chained for further processing.
- * @property {Function} resolver Resolves the promise when called.
  * @property {Function} rejecter Rejects the promise when called.
  * @property {Boolean} isFulfilled Whether original promise is already fulfilled.
  */

--- a/tests/adapters/base64uploadadapter.js
+++ b/tests/adapters/base64uploadadapter.js
@@ -140,7 +140,8 @@ describe( 'Base64UploadAdapter', () => {
 				const adapter = fileRepository.createLoader( createNativeFileMock() );
 
 				expect( () => {
-					adapter.upload();
+					// Catch the upload error to prevent uncaught promise errors
+					adapter.upload().catch( () => {} );
 					adapter.abort();
 				} ).to.not.throw();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add missing catch clauses to file loader promises.

---

### Additional information

* This is sub-pr for https://github.com/ckeditor/ckeditor5-image/pull/325

There were two cases in which there were unhandled promise rejections:
1. The first was missing catch clause on a promise from a loader file after it was then'ed
2. An edge case when a file read was aborted before uploading - the error was not properly thrown.

Other fixes was related to the tests itself.