### PR TITLE
fire an event on the FileRepository plugin when a new loader is created

### DIFF
--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -217,7 +217,7 @@ export default class FileRepository extends Plugin {
 
 			this.uploadTotal = aggregatedTotal;
 		} );
-		
+
 		this.fire( 'loaderCreated', loader );
 
 		return loader;

--- a/src/filerepository.js
+++ b/src/filerepository.js
@@ -217,6 +217,8 @@ export default class FileRepository extends Plugin {
 
 			this.uploadTotal = aggregatedTotal;
 		} );
+		
+		this.fire( 'loaderCreated', loader );
 
 		return loader;
 	}


### PR DESCRIPTION
Currently uploading is very restricted due to a lack of events that you usually get. We have no way to do anything with an upload after it is uploaded. Like this issue. https://github.com/ckeditor/ckeditor5/issues/2833

I wanted to add a bunch of events and also tried delegating some from the loader. I was looking at events used in ckeditor 4 and there are a lot there I would like, however one that basically means we have the power to do what we need, https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_fileTools_uploadRepository.html#event-instanceCreated. 

So this PR is basically to add that same event from ckeditor4 which means you can get access to the repsonse.

This is how I am using it.

```js
  listenToUpload(editor) {
    let fileRepository = editor.plugins.get('FileRepository');

    if (fileRepository) {
      fileRepository.on('loaderCreated', (event, loader) => {
        loader.on('change:uploadResponse', () => {
          if (loader.uploadResponse) {
            this.editorUpload(loader.uploadResponse);
          }
        });
      });
    }
  }
```