### PR TITLE
Feature: Add option formKey configuration

### DIFF
--- a/src/adapters/simpleuploadadapter.js
+++ b/src/adapters/simpleuploadadapter.js
@@ -208,7 +208,7 @@ class Adapter {
 		// Prepare the form data.
 		const data = new FormData();
 
-		data.append( 'upload', file );
+		data.append( this.options.formKey || 'upload', file );
 
 		// Send the request.
 		this.xhr.send( data );


### PR DESCRIPTION
Add optional configuration to change the form key used in the file upload. Currently `simpleUploadAdapter` uses the default form key `upload`. This change lets the user specify a key or, if none is specified, the default of `upload` is used.
